### PR TITLE
Fix spacing of "Skills" section pill elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
             padding: 5px;
             background-color: #ffb3d9;
             border: 1px solid #ff66b2;
+            margin-right: 0.25rem;
         }
 
         .contact p {


### PR DESCRIPTION
> # If you so wish and are **signed in**, you may **accept these changes** by pressing the "Merge Pull Request" -> "Confirm Merge"

Nice work, only one minor change I'd like to suggest:
Below we can see both images of how the UI is reflected on mobile and desktop:

### Desktop:
![image](https://github.com/user-attachments/assets/85db8585-e256-4e6c-b1bf-63c071f5bdc3)
### Mobile:
![image](https://github.com/user-attachments/assets/1b2c402e-9b08-495e-bc64-f3902505103b)

This is ok but doesn't particularly resonate well with the other elements in the user interface.

This is fixed by adding the CSS rule `margin-right: 0.25rem` into the CSS code of the selector `.skills ul li`:
![image](https://github.com/user-attachments/assets/b2579e98-e88d-4e8e-abe5-7668cbc9db82)


Below are the results of adding this one line of code to the page:

### Desktop:
![image](https://github.com/user-attachments/assets/f237585a-7f75-4b1f-a6b8-886926fdb9ab)

### Mobile:
![image](https://github.com/user-attachments/assets/9fbe5c68-a501-40d0-984d-db149a8dee4c)

